### PR TITLE
Gallery implementation

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-  presets: ['react', 'es2015'],
+  presets: ['react', 'es2015', 'stage-2'],
   plugins: ['transform-class-properties']
 }

--- a/package.json
+++ b/package.json
@@ -32,9 +32,14 @@
   "homepage": "https://github.com/simpixelated/react-es6-starter#readme",
   "dependencies": {
     "lodash": "4.0.1",
+    "material-ui": "^0.15.0-alpha.2",
     "moment": "2.11.2",
     "react": "0.14.7",
-    "react-dom": "0.14.7"
+    "react-addons-shallow-compare": "^15.0.1",
+    "react-dom": "0.14.7",
+    "react-redux": "^4.4.4",
+    "react-tap-event-plugin": "^0.2.2",
+    "redux": "^3.4.0"
   },
   "devDependencies": {
     "babel": "6.5.2",
@@ -46,11 +51,13 @@
     "babel-preset-es2015": "6.6.0",
     "babel-preset-react": "6.5.0",
     "babel-preset-stage-1": "6.5.0",
+    "babel-preset-stage-2": "^6.5.0",
     "css-loader": "0.23.1",
     "eslint": "2.2.0",
     "eslint-plugin-lodash": "1.2.1",
     "eslint-plugin-react": "4.1.0",
     "html-webpack-plugin": "2.9.0",
+    "muicss": "^0.5.1",
     "style-loader": "0.13.0",
     "webpack": "1.12.14",
     "webpack-dev-server": "1.14.1"

--- a/src/actions/dialog.js
+++ b/src/actions/dialog.js
@@ -1,0 +1,14 @@
+import {SHOW_DIALOG, HIDE_DIALOG} from '../constants/dialog';
+
+export function showDialog (opts) {
+  return {
+    type: SHOW_DIALOG,
+    ...opts
+  }
+}
+
+export function hideDialog () {
+  return {
+    type: HIDE_DIALOG
+  }
+}

--- a/src/components/confirm_dialog.js
+++ b/src/components/confirm_dialog.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import React, {Component, PropTypes} from 'react';
 import shouldComponentUpdate from 'react-addons-shallow-compare';
 
@@ -11,16 +12,17 @@ import * as actions from '../actions/dialog';
 
 class ConfirmDialog extends Component {
 
-  static propTypes () {
-    return {
-      dialog: PropTypes.shape({
-        title: PropTypes.func.isRwquired,
-        onConfirm: PropTypes.func.isRequired,
-        content: PropTypes.element,
-        open: PropTypes.bool
-      }),
-      hideDialog: PropTypes.func
-    };
+  static propTypes = {
+    dialog: PropTypes.shape({
+      title: PropTypes.func.isRequried,
+      onConfirm: PropTypes.func,
+      content: PropTypes.oneOfType([
+        PropTypes.element,
+        PropTypes.string
+      ]),
+      open: PropTypes.bool
+    }),
+    hideDialog: PropTypes.func
   }
 
   constructor () {
@@ -48,13 +50,11 @@ class ConfirmDialog extends Component {
         label="Cancel"
         secondary={true}
         keyboardFocused={true}
-        onClick={hideDialog}
         onTouchTap={hideDialog}
       />,
       <FlatButton
         label="Submit"
         primary={true}
-        onClick={this.handleConfirm}
         onTouchTap={this.handleConfirm}
       />
     ];
@@ -71,6 +71,10 @@ class ConfirmDialog extends Component {
       </Dialog>
     );
   }
+}
+
+ConfirmDialog.defaultProps = {
+  onConfirm: _.noop
 }
 
 export default connect(

--- a/src/components/confirm_dialog.js
+++ b/src/components/confirm_dialog.js
@@ -1,0 +1,79 @@
+import React, {Component, PropTypes} from 'react';
+import shouldComponentUpdate from 'react-addons-shallow-compare';
+
+import Dialog from 'material-ui/lib/dialog';
+import FlatButton from 'material-ui/lib/flat-button';
+
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+
+import * as actions from '../actions/dialog';
+
+class ConfirmDialog extends Component {
+
+  static propTypes () {
+    return {
+      dialog: PropTypes.shape({
+        title: PropTypes.func.isRwquired,
+        onConfirm: PropTypes.func.isRequired,
+        content: PropTypes.element,
+        open: PropTypes.bool
+      }),
+      hideDialog: PropTypes.func
+    };
+  }
+
+  constructor () {
+    super();
+    this.shouldComponentUpdate = shouldComponentUpdate.bind(this);
+    this.handleConfirm = this.handleConfirm.bind(this);
+  }
+
+  handleConfirm () {
+    this.props.hideDialog();
+    this.props.dialog.onConfirm();
+  }
+
+  render () {
+    const {dialog, hideDialog} = this.props;
+
+    if (!dialog.open) {
+      return null;
+    }
+
+    const {dialog: {title, open, content}} = this.props;
+
+    const actions = [
+      <FlatButton
+        label="Cancel"
+        secondary={true}
+        keyboardFocused={true}
+        onClick={hideDialog}
+        onTouchTap={hideDialog}
+      />,
+      <FlatButton
+        label="Submit"
+        primary={true}
+        onClick={this.handleConfirm}
+        onTouchTap={this.handleConfirm}
+      />
+    ];
+
+    return (
+      <Dialog
+        title={title}
+        actions={actions}
+        modal={false}
+        open={open}
+        onRequestClose={this.handleClose}
+      >
+        {content}
+      </Dialog>
+    );
+  }
+}
+
+export default connect(
+  state => ({ dialog: state.dialog }),
+  dispatch => bindActionCreators(actions, dispatch)
+)(ConfirmDialog);

--- a/src/components/photo_gallery.js
+++ b/src/components/photo_gallery.js
@@ -1,0 +1,145 @@
+import _ from 'lodash';
+import React, {Component, PropTypes} from 'react';
+import shouldComponentUpdate from 'react-addons-shallow-compare';
+
+import Row from 'muicss/lib/react/row';
+import Col from 'muicss/lib/react/col';
+import GridList from 'material-ui/lib/grid-list/grid-list';
+import RaisedButton from 'material-ui/lib/raised-button';
+import FontIcon from 'material-ui/lib/font-icon';
+
+import GalleryItem from './photo_gallery_item';
+
+export default class PhotoGallery extends Component {
+  static propTypes () {
+    return {
+      photos: PropTypes.array.isRequired,
+      editable: PropTypes.bool.isRequired,
+      onChange: PropTypes.func.isRequired,
+      showDialog: PropTypes.func
+    };
+  }
+
+  constructor () {
+    super();
+    this.state = {
+      photos: [],
+      selected: []
+    };
+
+    this.shouldComponentUpdate = shouldComponentUpdate.bind(this);
+
+    this.confirmDelete = this.confirmDelete.bind(this);
+    this.isSelected = this.isSelected.bind(this);
+    this.toggleSelected = this.toggleSelected.bind(this);
+    this.confirmBulkDelete = this.confirmBulkDelete.bind(this);
+  }
+
+  componentWillMount () {
+    this.setState({
+      photos: this.props.photos
+    });
+  }
+
+  isSelected (id) {
+    return this.state.selected.indexOf(id) >= 0;
+  }
+
+  toggleSelected (id) {
+    const {state} = this;
+
+    if (this.isSelected(id)) {
+      return this.setState({
+        ...state,
+        selected: _.without(state.selected, id)
+      });
+    }
+
+    this.setState({
+      ...state,
+      selected: [
+        ...state.selected,
+        id
+      ]
+    });
+  }
+
+  omitPhotos (ids) {
+    return _.filter(this.state.photos, (photo) => {
+      return ids.indexOf(photo.id) < 0;
+    })
+  }
+
+  confirmBulkDelete () {
+    const {state} = this;
+    const {showDialog, onChange} = this.props;
+    showDialog({
+      title: 'Confirm bulk deletion',
+      content: <div>Are you sure you want to delete <strong>{state.selected.length}</strong> images?</div>,
+      onConfirm: () => {
+        const photos = this.omitPhotos(state.selected);
+        this.setState({
+          ...state,
+          selected: [],
+          photos
+        }, () => onChange(photos));
+      }
+    })
+  }
+
+  confirmDelete (id) {
+    const {state} = this;
+    const {showDialog, onChange} = this.props;
+    showDialog({
+      title: 'Confirm deletion',
+      content: 'Are you sure you want to delete? This cannot be undone!',
+      onConfirm: () => {
+        const photos = this.omitPhotos([id]);
+        this.setState({
+          ...state,
+          photos
+        }, () => onChange(photos));
+      }
+    })
+  }
+
+  render () {
+    const {photos, selected} = this.state;
+    const {editable} = this.props;
+    return (
+      <Row>
+        <Row>
+          <Col md={10} md-offset={1} className='mb-20 mui--text-right'>
+            {editable &&
+              <RaisedButton
+                label="Delete Selected"
+                icon={<FontIcon className="material-icons">delete</FontIcon>}
+                disabled={!selected.length}
+                onClick={this.confirmBulkDelete}
+              />
+            }
+          </Col>
+        </Row>
+        <Row>
+          <Col md={10} md-offset={1}>
+            <GridList cellHeight={200}>
+              {_.map(photos, (photo, index) => {
+                return (
+                  <GalleryItem
+                    id={photo.id}
+                    url={photo.fileUrl}
+                    key={index}
+                    onDelete={this.confirmDelete}
+                    toggleSelected={this.toggleSelected}
+                    isSelected={this.isSelected(photo.id)}
+                    editable={editable}
+                  />
+                );
+              })}
+            </GridList>
+          </Col>
+        </Row>
+      </Row>
+    );
+  }
+}

--- a/src/components/photo_gallery.js
+++ b/src/components/photo_gallery.js
@@ -4,33 +4,28 @@ import shouldComponentUpdate from 'react-addons-shallow-compare';
 
 import Row from 'muicss/lib/react/row';
 import Col from 'muicss/lib/react/col';
-import GridList from 'material-ui/lib/grid-list/grid-list';
 import RaisedButton from 'material-ui/lib/raised-button';
 import FontIcon from 'material-ui/lib/font-icon';
 
-import GalleryItem from './photo_gallery_item';
+import GalleryItems from './photo_gallery_items';
 
 export default class PhotoGallery extends Component {
-  static propTypes () {
-    return {
-      photos: PropTypes.array.isRequired,
-      editable: PropTypes.bool.isRequired,
-      onChange: PropTypes.func.isRequired,
-      showDialog: PropTypes.func
-    };
+  static propTypes = {
+    photos: PropTypes.array.isRequired,
+    editable: PropTypes.bool.isRequired,
+    onChange: PropTypes.func.isRequired,
+    showDialog: PropTypes.func
   }
 
   constructor () {
     super();
     this.state = {
-      photos: [],
-      selected: []
+      photos: []
     };
 
     this.shouldComponentUpdate = shouldComponentUpdate.bind(this);
 
     this.confirmDelete = this.confirmDelete.bind(this);
-    this.isSelected = this.isSelected.bind(this);
     this.toggleSelected = this.toggleSelected.bind(this);
     this.confirmBulkDelete = this.confirmBulkDelete.bind(this);
   }
@@ -41,71 +36,56 @@ export default class PhotoGallery extends Component {
     });
   }
 
-  isSelected (id) {
-    return this.state.selected.indexOf(id) >= 0;
-  }
-
   toggleSelected (id) {
-    const {state} = this;
+    const {photos} = this.state;
 
-    if (this.isSelected(id)) {
-      return this.setState({
-        ...state,
-        selected: _.without(state.selected, id)
-      });
-    }
-
-    this.setState({
-      ...state,
-      selected: [
-        ...state.selected,
-        id
-      ]
+    return this.setState({
+      photos: _.map(photos, photo => {
+        if (photo.id === id) {
+          return {
+            ...photo,
+            selected: !photo.selected
+          };
+        }
+        return photo;
+      })
     });
   }
 
-  omitPhotos (ids) {
-    return _.filter(this.state.photos, (photo) => {
-      return ids.indexOf(photo.id) < 0;
-    })
+  getSelectedPhotosCount () {
+    return _.filter(this.state.photos, ['selected', true]).length;
   }
 
   confirmBulkDelete () {
-    const {state} = this;
     const {showDialog, onChange} = this.props;
+
     showDialog({
       title: 'Confirm bulk deletion',
-      content: <div>Are you sure you want to delete <strong>{state.selected.length}</strong> images?</div>,
+      content: <div>Are you sure you want to delete <strong>{this.getSelectedPhotosCount()}</strong> images?</div>,
       onConfirm: () => {
-        const photos = this.omitPhotos(state.selected);
-        this.setState({
-          ...state,
-          selected: [],
-          photos
-        }, () => onChange(photos));
+        const photos = _.filter(this.state.photos, ['selected', false]);
+        this.setState({ photos }, () => onChange(photos));
       }
     })
   }
 
   confirmDelete (id) {
-    const {state} = this;
     const {showDialog, onChange} = this.props;
     showDialog({
       title: 'Confirm deletion',
       content: 'Are you sure you want to delete? This cannot be undone!',
       onConfirm: () => {
-        const photos = this.omitPhotos([id]);
-        this.setState({
-          ...state,
-          photos
-        }, () => onChange(photos));
+        const photos = _.reject(this.state.photos, ['id', id]);
+        this.setState({ photos }, () => onChange(photos));
       }
     })
   }
 
   render () {
-    const {photos, selected} = this.state;
+    const {photos} = this.state;
     const {editable} = this.props;
+    const selectedPhotosCount = this.getSelectedPhotosCount();
+
     return (
       <Row>
         <Row>
@@ -114,7 +94,7 @@ export default class PhotoGallery extends Component {
               <RaisedButton
                 label="Delete Selected"
                 icon={<FontIcon className="material-icons">delete</FontIcon>}
-                disabled={!selected.length}
+                disabled={!selectedPhotosCount}
                 onClick={this.confirmBulkDelete}
               />
             }
@@ -122,21 +102,12 @@ export default class PhotoGallery extends Component {
         </Row>
         <Row>
           <Col md={10} md-offset={1}>
-            <GridList cellHeight={200}>
-              {_.map(photos, (photo, index) => {
-                return (
-                  <GalleryItem
-                    id={photo.id}
-                    url={photo.fileUrl}
-                    key={index}
-                    onDelete={this.confirmDelete}
-                    toggleSelected={this.toggleSelected}
-                    isSelected={this.isSelected(photo.id)}
-                    editable={editable}
-                  />
-                );
-              })}
-            </GridList>
+            <GalleryItems
+              photos={photos}
+              editable={editable}
+              confirmDelete={this.confirmDelete}
+              toggleSelected={this.toggleSelected}
+            />
           </Col>
         </Row>
       </Row>

--- a/src/components/photo_gallery_item.js
+++ b/src/components/photo_gallery_item.js
@@ -1,5 +1,4 @@
 import React, {Component, PropTypes} from 'react';
-import shouldComponentUpdate from 'react-addons-shallow-compare';
 
 import GridTile from 'material-ui/lib/grid-list/grid-tile';
 import Checkbox from 'material-ui/lib/checkbox';
@@ -11,43 +10,46 @@ import {openURL} from '../helpers/url';
 const TITLE_BACKGROUND = 'rgba(255, 255, 255, 0.76)';
 
 export default class PhotoGallery extends Component {
-  static propTypes () {
-    return {
-      id: PropTypes.number.isRequired,
-      url: PropTypes.string.isRequired,
-      editable: PropTypes.bool,
-      onDelete: PropTypes.func.isRequired,
-      toggleSelected: PropTypes.func.isRequired,
-      isSelected: PropTypes.bool.isRequired
-    };
+  static propTypes = {
+    photo: PropTypes.shape({
+      id: PropTypes.number,
+      fileUrl: PropTypes.string,
+      selected: PropTypes.bool
+    }).isRequired,
+    editable: PropTypes.bool,
+    onDelete: PropTypes.func.isRequired,
+    toggleSelected: PropTypes.func.isRequired
   }
 
   constructor () {
     super();
-    this.shouldComponentUpdate = shouldComponentUpdate.bind(this);
     this.deleteImage = this.deleteImage.bind(this);
     this.onCheck = this.onCheck.bind(this);
     this.openImage = this.openImage.bind(this);
   }
 
+  shouldComponentUpdate (nextProps) {
+    return this.props.photo !== nextProps.photo;
+  }
+
   deleteImage () {
-    this.props.onDelete(this.props.id);
+    this.props.onDelete(this.props.photo.id);
   }
 
   onCheck () {
-    this.props.toggleSelected(this.props.id);
+    this.props.toggleSelected(this.props.photo.id);
   }
 
   openImage () {
-    openURL(this.props.url);
+    openURL(this.props.photo.fileUrl);
   }
 
   renderActionsIcons () {
-    const {isSelected} = this.props;
+    const {photo: {selected}} = this.props;
     return (
       <div>
         <IconButton>
-          <Checkbox color="white" onCheck={this.onCheck} checked={isSelected}/>
+          <Checkbox color="white" onCheck={this.onCheck} checked={selected}/>
         </IconButton>
         <IconButton onClick={this.deleteImage}>
           <FontIcon className="material-icons">delete</FontIcon>
@@ -57,14 +59,14 @@ export default class PhotoGallery extends Component {
   }
 
   render () {
-    const {id, url, editable} = this.props;
+    const {photo: {id, fileUrl}, editable} = this.props;
     return (
       <GridTile
         title={<div></div>}
         titleBackground={editable ? TITLE_BACKGROUND : ''}
         actionIcon={editable ? this.renderActionsIcons(id) : null}
       >
-        <img src={url} onClick={this.openImage} className='pointer' />
+        <img src={fileUrl} onClick={this.openImage} className='pointer' />
       </GridTile>
     );
   }

--- a/src/components/photo_gallery_item.js
+++ b/src/components/photo_gallery_item.js
@@ -1,0 +1,71 @@
+import React, {Component, PropTypes} from 'react';
+import shouldComponentUpdate from 'react-addons-shallow-compare';
+
+import GridTile from 'material-ui/lib/grid-list/grid-tile';
+import Checkbox from 'material-ui/lib/checkbox';
+import IconButton from 'material-ui/lib/icon-button';
+import FontIcon from 'material-ui/lib/font-icon';
+
+import {openURL} from '../helpers/url';
+
+const TITLE_BACKGROUND = 'rgba(255, 255, 255, 0.76)';
+
+export default class PhotoGallery extends Component {
+  static propTypes () {
+    return {
+      id: PropTypes.number.isRequired,
+      url: PropTypes.string.isRequired,
+      editable: PropTypes.bool,
+      onDelete: PropTypes.func.isRequired,
+      toggleSelected: PropTypes.func.isRequired,
+      isSelected: PropTypes.bool.isRequired
+    };
+  }
+
+  constructor () {
+    super();
+    this.shouldComponentUpdate = shouldComponentUpdate.bind(this);
+    this.deleteImage = this.deleteImage.bind(this);
+    this.onCheck = this.onCheck.bind(this);
+    this.openImage = this.openImage.bind(this);
+  }
+
+  deleteImage () {
+    this.props.onDelete(this.props.id);
+  }
+
+  onCheck () {
+    this.props.toggleSelected(this.props.id);
+  }
+
+  openImage () {
+    openURL(this.props.url);
+  }
+
+  renderActionsIcons () {
+    const {isSelected} = this.props;
+    return (
+      <div>
+        <IconButton>
+          <Checkbox color="white" onCheck={this.onCheck} checked={isSelected}/>
+        </IconButton>
+        <IconButton onClick={this.deleteImage}>
+          <FontIcon className="material-icons">delete</FontIcon>
+        </IconButton>
+      </div>
+    );
+  }
+
+  render () {
+    const {id, url, editable} = this.props;
+    return (
+      <GridTile
+        title={<div></div>}
+        titleBackground={editable ? TITLE_BACKGROUND : ''}
+        actionIcon={editable ? this.renderActionsIcons(id) : null}
+      >
+        <img src={url} onClick={this.openImage} className='pointer' />
+      </GridTile>
+    );
+  }
+}

--- a/src/components/photo_gallery_items.js
+++ b/src/components/photo_gallery_items.js
@@ -1,0 +1,40 @@
+import _ from 'lodash';
+import React, {Component, PropTypes} from 'react';
+import shouldComponentUpdate from 'react-addons-shallow-compare';
+
+import GridList from 'material-ui/lib/grid-list/grid-list';
+
+import GalleryItem from './photo_gallery_item';
+
+export default class GalleryItems extends Component {
+  static propTypes = {
+    photos: PropTypes.array.isRequired,
+    editable: PropTypes.bool.isRequired,
+    confirmDelete: PropTypes.func.isRequired,
+    toggleSelected: PropTypes.func.isRequired
+  }
+
+  constructor () {
+    super();
+    this.shouldComponentUpdate = shouldComponentUpdate.bind(this);
+  }
+
+  render () {
+    const {photos, editable, confirmDelete, toggleSelected} = this.props;
+    return (
+      <GridList cellHeight={200}>
+        {_.map(photos, photo => {
+          return (
+            <GalleryItem
+              photo={photo}
+              key={photo.id}
+              onDelete={confirmDelete}
+              toggleSelected={toggleSelected}
+              editable={editable}
+            />
+          );
+        })}
+      </GridList>
+    )
+  }
+}

--- a/src/constants/dialog.js
+++ b/src/constants/dialog.js
@@ -1,0 +1,2 @@
+export const SHOW_DIALOG = 'SHOW_DIALOG';
+export const HIDE_DIALOG = 'HIDE_DIALOG';

--- a/src/helpers/url.js
+++ b/src/helpers/url.js
@@ -1,0 +1,7 @@
+export function openURL (url, newTab = true) {
+  if (newTab) {
+    return window.open(url, '_blank');
+  }
+
+  window.open(url);
+}

--- a/src/index.html
+++ b/src/index.html
@@ -4,6 +4,8 @@
     <title>React ES6 Starter</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <link href='https://fonts.googleapis.com/css?family=Roboto:400,300,500' rel='stylesheet' type='text/css'>
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   </head>
   <body>
     <div id="root"></div>

--- a/src/index.js
+++ b/src/index.js
@@ -4,10 +4,13 @@ require('!style!css!muicss/lib/css/mui.css');
 import React from 'react';
 import { render } from 'react-dom';
 import { Provider } from 'react-redux';
+import injectTapEventPlugin from 'react-tap-event-plugin';
 
 import store from './store';
 
 import Layout from './layout';
+
+injectTapEventPlugin();
 
 render(
   <Provider store={store}>

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,17 @@
+require('!style!css!./styles/index.css');
+require('!style!css!muicss/lib/css/mui.css');
+
 import React from 'react';
 import { render } from 'react-dom';
+import { Provider } from 'react-redux';
+
+import store from './store';
+
+import Layout from './layout';
 
 render(
-  <h1>React ES6 Starter</h1>,
+  <Provider store={store}>
+    <Layout />
+  </Provider>,
   document.getElementById('root')
 );

--- a/src/layout.js
+++ b/src/layout.js
@@ -34,7 +34,7 @@ class Layout extends Component {
     this.shouldComponentUpdate = shouldComponentUpdate.bind(this);
   }
 
-  onProfileGalleryUpdate (images) {
+  onProfileGalleryUpdate (images) { // eslint-disable-line no-unused-vars
     //TODO Use the data.
   }
 

--- a/src/layout.js
+++ b/src/layout.js
@@ -42,13 +42,13 @@ class Layout extends Component {
     return (
       <div className='container'>
        <Row>
-         <Col md='8' md-offset='2'>
+         <Col md='6' md-offset='3'>
            <div className='mui--text-display1 headline'>
              Photo Gallery
            </div>
            <Panel>
              <PhotoGallery
-               photos={generatePhotos(10)}
+               photos={generatePhotos(25)}
                onChange={this.onProfileGalleryUpdate}
                editable={true}
                {...this.props}

--- a/src/layout.js
+++ b/src/layout.js
@@ -1,0 +1,68 @@
+import _ from 'lodash';
+import React, {Component, PropTypes} from 'react';
+import shouldComponentUpdate from 'react-addons-shallow-compare';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+
+import Row from 'muicss/lib/react/row';
+import Col from 'muicss/lib/react/col';
+import Panel from 'muicss/lib/react/panel';
+
+import ConfirmDialog from './components/confirm_dialog';
+import PhotoGallery from './components/photo_gallery';
+
+import {showDialog} from './actions/dialog';
+
+const generatePhotos = (amount = 20) => {
+  return _.map(_.range(0, amount), id => ({
+    id,
+    fileUrl: `https://unsplash.it/200/300/?image=${id}`
+  }));
+}
+
+class Layout extends Component {
+
+  static propTypes () {
+    return {
+      showDialog: PropTypes.func
+    };
+  }
+
+  constructor () {
+    super();
+    this.onProfileGalleryUpdate = this.onProfileGalleryUpdate.bind(this);
+    this.shouldComponentUpdate = shouldComponentUpdate.bind(this);
+  }
+
+  onProfileGalleryUpdate (images) {
+    //TODO Use the data.
+  }
+
+  render () {
+    return (
+      <div className='container'>
+       <Row>
+         <Col md='8' md-offset='2'>
+           <div className='mui--text-display1 headline'>
+             Photo Gallery
+           </div>
+           <Panel>
+             <PhotoGallery
+               photos={generatePhotos(10)}
+               onChange={this.onProfileGalleryUpdate}
+               editable={true}
+               {...this.props}
+             />
+          </Panel>
+         </Col>
+       </Row>
+       <ConfirmDialog />
+      </div>
+    );
+  }
+}
+
+export default connect(
+  undefined,
+  dispatch => bindActionCreators({ showDialog }, dispatch)
+)(Layout);

--- a/src/layout.js
+++ b/src/layout.js
@@ -16,16 +16,15 @@ import {showDialog} from './actions/dialog';
 const generatePhotos = (amount = 20) => {
   return _.map(_.range(0, amount), id => ({
     id,
-    fileUrl: `https://unsplash.it/200/300/?image=${id}`
+    fileUrl: `https://unsplash.it/200/300/?image=${id}`,
+    selected: false
   }));
 }
 
 class Layout extends Component {
 
-  static propTypes () {
-    return {
-      showDialog: PropTypes.func
-    };
+  static propTypes = {
+    showDialog: PropTypes.func
   }
 
   constructor () {

--- a/src/reducers/dialog.js
+++ b/src/reducers/dialog.js
@@ -1,0 +1,17 @@
+import _ from 'lodash';
+import {SHOW_DIALOG, HIDE_DIALOG} from '../constants/dialog';
+
+export default function Dialog (state = { open: false }, action) {
+  switch(action.type) {
+    case SHOW_DIALOG:
+      return {
+        ..._.omit(action, 'type'),
+        open: true
+      };
+    case HIDE_DIALOG:
+      return {
+        open: false
+      };
+  }
+  return state;
+}

--- a/src/store.js
+++ b/src/store.js
@@ -1,0 +1,9 @@
+import { createStore, combineReducers } from 'redux';
+
+import dialog from './reducers/dialog';
+
+export default createStore(
+  combineReducers({
+    dialog
+  })
+);

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,0 +1,25 @@
+html {
+  font-family: 'Roboto', sans-serif;
+}
+
+.container {
+  padding: 100px 0px;
+}
+
+.container .headline {
+  padding: 10px;
+}
+
+.tile-actions {
+  position: absolute;
+  right: 10px;
+  top: 10px;
+}
+
+.mb-20 {
+  margin-bottom: 20px;
+}
+
+.pointer {
+  cursor: pointer !important;
+}


### PR DESCRIPTION
Hey @simpixelated,

Following has been implemented:
**Acceptance Criteria**
[done] photos are displayed as thumbnails in a list or grid view
[done] clicking a thumbnail opens full size image in a new tab
[done] each thumbnail has a checkmark for selecting and a trash can icon for deleting
[done] can select multiple images and click a single button to delete from gallery
[done] deleting image(s) will prompt the user to confirm

**Stretch Goals**

[done] allow "read only" view to be set via props, which should hide icons and disable sorting
images can be re-ordered
super stretch goal: images can be re-ordered by drag and drop

Notes: 
- I have changed from loremflickr to unsplash.it as the loading times on loremflickr are really bad..
- I have added redux to manage the Dialog displaying/content as doing that without it would be a mess. (hope you do not mind)

In case you have any questions/concerns/comments I would be happy to hear/improve.

Cheers,
